### PR TITLE
gnrc_ppp: Better modeling of link up/down

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -88,6 +88,11 @@ ifneq (,$(filter netdev2_tap,$(USEMODULE)))
   endif
 endif
 
+ifneq (,$(filter gnrc_ppp,$(USEMODULE)))
+  USEMODULE += gnrc_netdev
+  USEMODULE += gnrc_netdev_msg_handler
+endif
+
 ifneq (,$(filter gnrc_zep,$(USEMODULE)))
   USEMODULE += hashes
   USEMODULE += ieee802154

--- a/Makefile.pseudomodules
+++ b/Makefile.pseudomodules
@@ -11,6 +11,7 @@ PSEUDOMODULES += gnrc_ipv6_default
 PSEUDOMODULES += gnrc_ipv6_router
 PSEUDOMODULES += gnrc_ipv6_router_default
 PSEUDOMODULES += gnrc_netdev_default
+PSEUDOMODULES += gnrc_netdev_msg_handler
 PSEUDOMODULES += gnrc_neterr
 PSEUDOMODULES += gnrc_netapi_callbacks
 PSEUDOMODULES += gnrc_netapi_mbox

--- a/drivers/netdev2_ppp/netdev2_ppp.c
+++ b/drivers/netdev2_ppp/netdev2_ppp.c
@@ -51,6 +51,13 @@ int netdev2_ppp_get(netdev2_ppp_t *dev, netopt_t opt, void *value, size_t max_le
             *((uint16_t*) value) = NETDEV2_TYPE_PPP;
             res = 2;
             break;
+        case NETOPT_LINK_STATE: {
+                gnrc_ppp_protocol_t *dcp = (gnrc_ppp_protocol_t *) &dev->dcp;
+                *((netopt_enable_t *)value) = (dcp->state == PROTOCOL_DOWN) ?
+                                              NETOPT_DISABLE : NETOPT_ENABLE;
+                res = sizeof(netopt_enable_t);
+            };
+            break;
         default:
             return -ENOTSUP;
             break;
@@ -79,6 +86,16 @@ int netdev2_ppp_set(netdev2_ppp_t *dev, netopt_t opt, void *value, size_t value_
             memcpy(dev->pap.password, value, value_len);
             dev->pap.pass_size = value_len;
             res = 0;
+            break;
+        case NETOPT_LINK_STATE:
+            if (*((netopt_enable_t *)value) == NETOPT_DISABLE) {
+                /* set link down in device context
+                 * should not require dispatch_ppp_msg */
+            }
+            else {
+                /* set link up in device context
+                 * should not require dispatch_ppp_msg */
+            }
             break;
         default:
             return -ENOTSUP;

--- a/sys/include/net/gnrc/netdev2.h
+++ b/sys/include/net/gnrc/netdev2.h
@@ -80,27 +80,16 @@ typedef struct gnrc_netdev2 {
      */
     int (*send)(struct gnrc_netdev2 *dev, gnrc_pktsnip_t *snip);
 
-
+#if defined(MODULE_GNRC_NETDEV_MSG_HANDLER) || DOXYGEN
     /**
      * @brief Handle custom messages
      *
-     * This function handles messages that are not present in gnrc_netdev2 loop.
+     * This function handles additional message types to the 
+     * @ref net_gnrc_netapi messages.
+     *
+     * @note Only available with gnrc_netdev_msg_handler pseudo-module.
      */
     int (*msg_handler)(struct gnrc_netdev2 *dev, msg_t *msg);
-#if defined(MODULE_GNRC_PPP) || doxygen
-    /**
-     * @brief Handle link up event from this device
-     *
-     * This function handles link up events from device. 
-     */
-    int (*link_up)(struct gnrc_netdev2 *dev);
-
-    /**
-     * @brief Handle link down event from this device
-     *
-     * This function handles link down events from device. 
-     */
-    int (*link_down)(struct gnrc_netdev2 *dev);
 #endif
     /**
      * @brief Receive a pktsnip from this device

--- a/sys/include/net/netopt.h
+++ b/sys/include/net/netopt.h
@@ -321,6 +321,14 @@ typedef enum {
      */
     NETOPT_RF_TESTMODE,
 
+    /**
+     * @brief   Set link state of the device.
+     *
+     * Expects type @ref netopt_enable_t. @ref NETOPT_DISABLE sets the link
+     * down, @ref NETOPT_ENABLE sets the link up.
+     */
+    NETOPT_LINK_STATE,
+
     /* add more options if needed */
 
     /**

--- a/sys/net/gnrc/link_layer/netdev2/gnrc_netdev2_ppp.c
+++ b/sys/net/gnrc/link_layer/netdev2/gnrc_netdev2_ppp.c
@@ -42,22 +42,6 @@ static int _send(gnrc_netdev2_t *dev, gnrc_pktsnip_t *pkt)
     return 0;
 }
 
-static int _link_up(gnrc_netdev2_t *dev)
-{
-    dispatch_ppp_msg(dev, (0xFF00) | (PPP_LINKDOWN&0xFF));
-    dispatch_ppp_msg(dev, (0xFF00) | (PPP_LINKUP&0xFF));
-    return 0;
-}
-
-static int _link_down(gnrc_netdev2_t *dev)
-{
-    netdev2_ppp_t *pppdev = (netdev2_ppp_t*) dev->dev;
-    gnrc_ppp_protocol_t *dcp = (gnrc_ppp_protocol_t*) &pppdev->dcp;
-    dcp->state = PROTOCOL_DOWN;
-    dispatch_ppp_msg(dev, ((PROT_LCP<<8)&0xFF00) | (PPP_LINKDOWN & 0xFF));
-    return 0;
-}
-
 static int msg_handler(gnrc_netdev2_t *dev, msg_t *msg)
 {
     int event = msg->content.value;
@@ -75,8 +59,6 @@ void gnrc_netdev2_ppp_init(gnrc_netdev2_t *gnrc_netdev2, netdev2_ppp_t *dev)
 
     gnrc_netdev2->send = _send;
     gnrc_netdev2->recv = _recv;
-    gnrc_netdev2->link_up = _link_up;
-    gnrc_netdev2->link_down = _link_down;
     gnrc_netdev2->msg_handler = msg_handler;
     gnrc_netdev2->dev = (netdev2_t *) dev;
 }


### PR DESCRIPTION
This provides link-up/link-down to netdev without major changes to the interface of `netdev`/`gnrc_netdev`.